### PR TITLE
fix: preserve dynamic imports in CommonJS files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
 			"version": "0.0.3",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@rollup/plugin-typescript": "^8.5.0",
+				"@rollup/plugin-typescript": "^9.0.2",
 				"defu": "^6.1.0",
 				"fs-extra": "^10.1.0"
 			},
 			"devDependencies": {
 				"@size-limit/preset-small-lib": "^8.1.0",
 				"@types/fs-extra": "^9.0.13",
-				"@typescript-eslint/eslint-plugin": "~5.39.0",
-				"@typescript-eslint/parser": "^5.39.0",
-				"@vitest/coverage-c8": "^0.23.4",
-				"eslint": "^8.24.0",
+				"@typescript-eslint/eslint-plugin": "~5.42.0",
+				"@typescript-eslint/parser": "^5.42.0",
+				"@vitest/coverage-c8": "^0.24.5",
+				"eslint": "^8.26.0",
 				"eslint-config-prettier": "^8.5.0",
 				"eslint-plugin-prettier": "^4.2.1",
 				"eslint-plugin-tsdoc": "^0.2.17",
@@ -28,8 +28,8 @@
 				"size-limit": "^8.1.0",
 				"standard-version": "^9.5.0",
 				"typescript": "^4.8.4",
-				"vite": "^3.1.4",
-				"vitest": "^0.23.4"
+				"vite": "^3.2.2",
+				"vitest": "^0.24.5"
 			},
 			"engines": {
 				"node": ">=14.15.0"
@@ -183,9 +183,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
-			"integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+			"integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
@@ -206,27 +206,17 @@
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.10.5",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.5.tgz",
-			"integrity": "sha512-XVVDtp+dVvRxMoxSiSfasYaG02VEe1qH5cKgMQJWhol6HwzbcqoCMJi8dAGoYAO57jhUyhI6cWuRiTcRaDaYug==",
+			"version": "0.11.7",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
+			"integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
 			"dev": true,
 			"dependencies": {
 				"@humanwhocodes/object-schema": "^1.2.1",
 				"debug": "^4.1.1",
-				"minimatch": "^3.0.4"
+				"minimatch": "^3.0.5"
 			},
 			"engines": {
 				"node": ">=10.10.0"
-			}
-		},
-		"node_modules/@humanwhocodes/gitignore-to-minimatch": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-			"integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
-			"dev": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
 		"node_modules/@humanwhocodes/module-importer": {
@@ -358,41 +348,49 @@
 			}
 		},
 		"node_modules/@rollup/plugin-typescript": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.5.0.tgz",
-			"integrity": "sha512-wMv1/scv0m/rXx21wD2IsBbJFba8wGF3ErJIr6IKRfRj49S85Lszbxb4DCo8iILpluTjk2GAAu9CoZt4G3ppgQ==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-9.0.2.tgz",
+			"integrity": "sha512-/sS93vmHUMjzDUsl5scNQr1mUlNE1QjBBvOhmRwJCH8k2RRhDIm3c977B3wdu3t3Ap17W6dDeXP3hj1P1Un1bA==",
 			"dependencies": {
-				"@rollup/pluginutils": "^3.1.0",
-				"resolve": "^1.17.0"
+				"@rollup/pluginutils": "^5.0.1",
+				"resolve": "^1.22.1"
 			},
 			"engines": {
-				"node": ">=8.0.0"
+				"node": ">=14.0.0"
 			},
 			"peerDependencies": {
-				"rollup": "^2.14.0",
+				"rollup": "^2.14.0||^3.0.0",
 				"tslib": "*",
 				"typescript": ">=3.7.0"
 			},
 			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				},
 				"tslib": {
 					"optional": true
 				}
 			}
 		},
 		"node_modules/@rollup/pluginutils": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+			"integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
 			"dependencies": {
-				"@types/estree": "0.0.39",
-				"estree-walker": "^1.0.1",
-				"picomatch": "^2.2.2"
+				"@types/estree": "^1.0.0",
+				"estree-walker": "^2.0.2",
+				"picomatch": "^2.3.1"
 			},
 			"engines": {
-				"node": ">= 8.0.0"
+				"node": ">=14.0.0"
 			},
 			"peerDependencies": {
-				"rollup": "^1.20.0||^2.0.0"
+				"rollup": "^1.20.0||^2.0.0||^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@size-limit/esbuild": {
@@ -464,9 +462,9 @@
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "0.0.39",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+			"integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ=="
 		},
 		"node_modules/@types/fs-extra": {
 			"version": "9.0.13",
@@ -522,6 +520,12 @@
 			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
 			"dev": true
 		},
+		"node_modules/@types/semver": {
+			"version": "7.3.13",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+			"integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+			"dev": true
+		},
 		"node_modules/@types/unist": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
@@ -529,16 +533,17 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.39.0.tgz",
-			"integrity": "sha512-xVfKOkBm5iWMNGKQ2fwX5GVgBuHmZBO1tCRwXmY5oAIsPscfwm2UADDuNB8ZVYCtpQvJK4xpjrK7jEhcJ0zY9A==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.42.0.tgz",
+			"integrity": "sha512-5TJh2AgL6+wpL8H/GTSjNb4WrjKoR2rqvFxR/DDTqYNk6uXn8BJMEcncLSpMbf/XV1aS0jAjYwn98uvVCiAywQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.39.0",
-				"@typescript-eslint/type-utils": "5.39.0",
-				"@typescript-eslint/utils": "5.39.0",
+				"@typescript-eslint/scope-manager": "5.42.0",
+				"@typescript-eslint/type-utils": "5.42.0",
+				"@typescript-eslint/utils": "5.42.0",
 				"debug": "^4.3.4",
 				"ignore": "^5.2.0",
+				"natural-compare-lite": "^1.4.0",
 				"regexpp": "^3.2.0",
 				"semver": "^7.3.7",
 				"tsutils": "^3.21.0"
@@ -561,14 +566,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.39.0.tgz",
-			"integrity": "sha512-PhxLjrZnHShe431sBAGHaNe6BDdxAASDySgsBCGxcBecVCi8NQWxQZMcizNA4g0pN51bBAn/FUfkWG3SDVcGlA==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.42.0.tgz",
+			"integrity": "sha512-Ixh9qrOTDRctFg3yIwrLkgf33AHyEIn6lhyf5cCfwwiGtkWhNpVKlEZApi3inGQR/barWnY7qY8FbGKBO7p3JA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.39.0",
-				"@typescript-eslint/types": "5.39.0",
-				"@typescript-eslint/typescript-estree": "5.39.0",
+				"@typescript-eslint/scope-manager": "5.42.0",
+				"@typescript-eslint/types": "5.42.0",
+				"@typescript-eslint/typescript-estree": "5.42.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -588,13 +593,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.39.0.tgz",
-			"integrity": "sha512-/I13vAqmG3dyqMVSZPjsbuNQlYS082Y7OMkwhCfLXYsmlI0ca4nkL7wJ/4gjX70LD4P8Hnw1JywUVVAwepURBw==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.42.0.tgz",
+			"integrity": "sha512-l5/3IBHLH0Bv04y+H+zlcLiEMEMjWGaCX6WyHE5Uk2YkSGAMlgdUPsT/ywTSKgu9D1dmmKMYgYZijObfA39Wow==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.39.0",
-				"@typescript-eslint/visitor-keys": "5.39.0"
+				"@typescript-eslint/types": "5.42.0",
+				"@typescript-eslint/visitor-keys": "5.42.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -605,13 +610,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.39.0.tgz",
-			"integrity": "sha512-KJHJkOothljQWzR3t/GunL0TPKY+fGJtnpl+pX+sJ0YiKTz3q2Zr87SGTmFqsCMFrLt5E0+o+S6eQY0FAXj9uA==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.42.0.tgz",
+			"integrity": "sha512-HW14TXC45dFVZxnVW8rnUGnvYyRC0E/vxXShFCthcC9VhVTmjqOmtqj6H5rm9Zxv+ORxKA/1aLGD7vmlLsdlOg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "5.39.0",
-				"@typescript-eslint/utils": "5.39.0",
+				"@typescript-eslint/typescript-estree": "5.42.0",
+				"@typescript-eslint/utils": "5.42.0",
 				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
 			},
@@ -632,9 +637,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.39.0.tgz",
-			"integrity": "sha512-gQMZrnfEBFXK38hYqt8Lkwt8f4U6yq+2H5VDSgP/qiTzC8Nw8JO3OuSUOQ2qW37S/dlwdkHDntkZM6SQhKyPhw==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.42.0.tgz",
+			"integrity": "sha512-t4lzO9ZOAUcHY6bXQYRuu+3SSYdD9TS8ooApZft4WARt4/f2Cj/YpvbTe8A4GuhT4bNW72goDMOy7SW71mZwGw==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -645,13 +650,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.39.0.tgz",
-			"integrity": "sha512-qLFQP0f398sdnogJoLtd43pUgB18Q50QSA+BTE5h3sUxySzbWDpTSdgt4UyxNSozY/oDK2ta6HVAzvGgq8JYnA==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.0.tgz",
+			"integrity": "sha512-2O3vSq794x3kZGtV7i4SCWZWCwjEtkWfVqX4m5fbUBomOsEOyd6OAD1qU2lbvV5S8tgy/luJnOYluNyYVeOTTg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.39.0",
-				"@typescript-eslint/visitor-keys": "5.39.0",
+				"@typescript-eslint/types": "5.42.0",
+				"@typescript-eslint/visitor-keys": "5.42.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -672,17 +677,19 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.39.0.tgz",
-			"integrity": "sha512-+DnY5jkpOpgj+EBtYPyHRjXampJfC0yUZZzfzLuUWVZvCuKqSdJVC8UhdWipIw7VKNTfwfAPiOWzYkAwuIhiAg==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.42.0.tgz",
+			"integrity": "sha512-JZ++3+h1vbeG1NUECXQZE3hg0kias9kOtcQr3+JVQ3whnjvKuMyktJAAIj6743OeNPnGBmjj7KEmiDL7qsdnCQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.39.0",
-				"@typescript-eslint/types": "5.39.0",
-				"@typescript-eslint/typescript-estree": "5.39.0",
+				"@types/semver": "^7.3.12",
+				"@typescript-eslint/scope-manager": "5.42.0",
+				"@typescript-eslint/types": "5.42.0",
+				"@typescript-eslint/typescript-estree": "5.42.0",
 				"eslint-scope": "^5.1.1",
-				"eslint-utils": "^3.0.0"
+				"eslint-utils": "^3.0.0",
+				"semver": "^7.3.7"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -696,12 +703,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.39.0.tgz",
-			"integrity": "sha512-yyE3RPwOG+XJBLrhvsxAidUgybJVQ/hG8BhiJo0k8JSAYfk/CshVcxf0HwP4Jt7WZZ6vLmxdo1p6EyN3tzFTkg==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.0.tgz",
+			"integrity": "sha512-QHbu5Hf/2lOEOwy+IUw0GoSCuAzByTAWWrOTKzTzsotiUnWFpuKnXcAhC9YztAf2EElQ0VvIK+pHJUPkM0q7jg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.39.0",
+				"@typescript-eslint/types": "5.42.0",
 				"eslint-visitor-keys": "^3.3.0"
 			},
 			"engines": {
@@ -713,22 +720,22 @@
 			}
 		},
 		"node_modules/@vitest/coverage-c8": {
-			"version": "0.23.4",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.23.4.tgz",
-			"integrity": "sha512-jmD00a5DQH9gu9K+YdvVhcMuv2CzHvU4gCnySS40Ec5hKlXtlCzRfNHl00VnhfuBeaQUmaQYe60BLT413HyDdg==",
+			"version": "0.24.5",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.24.5.tgz",
+			"integrity": "sha512-955yK/SdSBZPYrSXgXB0F+0JnOX5EY9kSL7ywJ4rNajmkFUhwLjuKm13Xb6YKSyIY/g5WvbBnyowqfNRxBJ3ww==",
 			"dev": true,
 			"dependencies": {
 				"c8": "^7.12.0",
-				"vitest": "0.23.4"
+				"vitest": "0.24.5"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-			"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -2068,15 +2075,15 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.24.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.24.0.tgz",
-			"integrity": "sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
+			"integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
 			"dev": true,
 			"dependencies": {
-				"@eslint/eslintrc": "^1.3.2",
-				"@humanwhocodes/config-array": "^0.10.5",
-				"@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+				"@eslint/eslintrc": "^1.3.3",
+				"@humanwhocodes/config-array": "^0.11.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
+				"@nodelib/fs.walk": "^1.2.8",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -2092,14 +2099,14 @@
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"find-up": "^5.0.0",
-				"glob-parent": "^6.0.1",
+				"glob-parent": "^6.0.2",
 				"globals": "^13.15.0",
-				"globby": "^11.1.0",
 				"grapheme-splitter": "^1.0.4",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
+				"is-path-inside": "^3.0.3",
 				"js-sdsl": "^4.1.4",
 				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
@@ -2306,9 +2313,9 @@
 			}
 		},
 		"node_modules/estree-walker": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
 		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
@@ -2499,6 +2506,7 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
 			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
 			"hasInstallScript": true,
 			"optional": true,
 			"os": [
@@ -2938,6 +2946,15 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
 			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-path-inside": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=8"
@@ -4067,6 +4084,12 @@
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
 		},
+		"node_modules/natural-compare-lite": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+			"dev": true
+		},
 		"node_modules/neo-async": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -4264,9 +4287,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.16",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-			"integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+			"version": "8.4.18",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
+			"integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
 			"dev": true,
 			"funding": [
 				{
@@ -4650,7 +4673,7 @@
 			"version": "2.79.1",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
 			"integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
-			"peer": true,
+			"devOptional": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
 			},
@@ -5113,9 +5136,9 @@
 			}
 		},
 		"node_modules/tinybench": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.1.5.tgz",
-			"integrity": "sha512-ak+PZZEuH3mw6CCFOgf5S90YH0MARnZNhxjhjguAmoJimEMAJuNip/rJRd6/wyylHItomVpKTzZk9zrhTrQCoQ==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.3.1.tgz",
+			"integrity": "sha512-hGYWYBMPr7p4g5IarQE7XhlyWveh1EKhy4wUBS1LrHXCKYgvz+4/jCqgmJqZxxldesn05vccrtME2RLLZNW7iA==",
 			"dev": true
 		},
 		"node_modules/tinypool": {
@@ -5321,15 +5344,15 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-3.1.4.tgz",
-			"integrity": "sha512-JoQI08aBjY9lycL7jcEq4p9o1xUjq5aRvdH4KWaXtkSx7e7RpAh9D3IjzDWRD4Fg44LS3oDAIOG/Kq1L+82psA==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-3.2.2.tgz",
+			"integrity": "sha512-pLrhatFFOWO9kS19bQ658CnRYzv0WLbsPih6R+iFeEEhDOuYgYCX2rztUViMz/uy/V8cLCJvLFeiOK7RJEzHcw==",
 			"dev": true,
 			"dependencies": {
-				"esbuild": "^0.15.6",
-				"postcss": "^8.4.16",
+				"esbuild": "^0.15.9",
+				"postcss": "^8.4.18",
 				"resolve": "^1.22.1",
-				"rollup": "~2.78.0"
+				"rollup": "^2.79.1"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -5344,6 +5367,7 @@
 				"less": "*",
 				"sass": "*",
 				"stylus": "*",
+				"sugarss": "*",
 				"terser": "^5.4.0"
 			},
 			"peerDependenciesMeta": {
@@ -5356,30 +5380,18 @@
 				"stylus": {
 					"optional": true
 				},
+				"sugarss": {
+					"optional": true
+				},
 				"terser": {
 					"optional": true
 				}
 			}
 		},
-		"node_modules/vite/node_modules/rollup": {
-			"version": "2.78.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
-			"integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
-			"dev": true,
-			"bin": {
-				"rollup": "dist/bin/rollup"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.2"
-			}
-		},
 		"node_modules/vitest": {
-			"version": "0.23.4",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.23.4.tgz",
-			"integrity": "sha512-iukBNWqQAv8EKDBUNntspLp9SfpaVFbmzmM0sNcnTxASQZMzRw3PsM6DMlsHiI+I6GeO5/sYDg3ecpC+SNFLrQ==",
+			"version": "0.24.5",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.24.5.tgz",
+			"integrity": "sha512-zw6JhPUHtLILQDe5Q39b/SzoITkG+R7hcFjuthp4xsi6zpmfQPOZcHodZ+3bqoWl4EdGK/p1fuMiEwdxgbGLOA==",
 			"dev": true,
 			"dependencies": {
 				"@types/chai": "^4.3.3",
@@ -5388,11 +5400,11 @@
 				"chai": "^4.3.6",
 				"debug": "^4.3.4",
 				"local-pkg": "^0.4.2",
-				"strip-literal": "^0.4.1",
-				"tinybench": "^2.1.5",
+				"strip-literal": "^0.4.2",
+				"tinybench": "^2.3.1",
 				"tinypool": "^0.3.0",
 				"tinyspy": "^1.0.2",
-				"vite": "^2.9.12 || ^3.0.0-0"
+				"vite": "^3.0.0"
 			},
 			"bin": {
 				"vitest": "vitest.mjs"
@@ -5651,9 +5663,9 @@
 			"optional": true
 		},
 		"@eslint/eslintrc": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
-			"integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+			"integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
@@ -5668,21 +5680,15 @@
 			}
 		},
 		"@humanwhocodes/config-array": {
-			"version": "0.10.5",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.5.tgz",
-			"integrity": "sha512-XVVDtp+dVvRxMoxSiSfasYaG02VEe1qH5cKgMQJWhol6HwzbcqoCMJi8dAGoYAO57jhUyhI6cWuRiTcRaDaYug==",
+			"version": "0.11.7",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
+			"integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
 			"dev": true,
 			"requires": {
 				"@humanwhocodes/object-schema": "^1.2.1",
 				"debug": "^4.1.1",
-				"minimatch": "^3.0.4"
+				"minimatch": "^3.0.5"
 			}
-		},
-		"@humanwhocodes/gitignore-to-minimatch": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-			"integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
-			"dev": true
 		},
 		"@humanwhocodes/module-importer": {
 			"version": "1.0.1",
@@ -5787,22 +5793,22 @@
 			}
 		},
 		"@rollup/plugin-typescript": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.5.0.tgz",
-			"integrity": "sha512-wMv1/scv0m/rXx21wD2IsBbJFba8wGF3ErJIr6IKRfRj49S85Lszbxb4DCo8iILpluTjk2GAAu9CoZt4G3ppgQ==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-9.0.2.tgz",
+			"integrity": "sha512-/sS93vmHUMjzDUsl5scNQr1mUlNE1QjBBvOhmRwJCH8k2RRhDIm3c977B3wdu3t3Ap17W6dDeXP3hj1P1Un1bA==",
 			"requires": {
-				"@rollup/pluginutils": "^3.1.0",
-				"resolve": "^1.17.0"
+				"@rollup/pluginutils": "^5.0.1",
+				"resolve": "^1.22.1"
 			}
 		},
 		"@rollup/pluginutils": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+			"integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
 			"requires": {
-				"@types/estree": "0.0.39",
-				"estree-walker": "^1.0.1",
-				"picomatch": "^2.2.2"
+				"@types/estree": "^1.0.0",
+				"estree-walker": "^2.0.2",
+				"picomatch": "^2.3.1"
 			}
 		},
 		"@size-limit/esbuild": {
@@ -5859,9 +5865,9 @@
 			}
 		},
 		"@types/estree": {
-			"version": "0.0.39",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+			"integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ=="
 		},
 		"@types/fs-extra": {
 			"version": "9.0.13",
@@ -5917,6 +5923,12 @@
 			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
 			"dev": true
 		},
+		"@types/semver": {
+			"version": "7.3.13",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+			"integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+			"dev": true
+		},
 		"@types/unist": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
@@ -5924,69 +5936,70 @@
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.39.0.tgz",
-			"integrity": "sha512-xVfKOkBm5iWMNGKQ2fwX5GVgBuHmZBO1tCRwXmY5oAIsPscfwm2UADDuNB8ZVYCtpQvJK4xpjrK7jEhcJ0zY9A==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.42.0.tgz",
+			"integrity": "sha512-5TJh2AgL6+wpL8H/GTSjNb4WrjKoR2rqvFxR/DDTqYNk6uXn8BJMEcncLSpMbf/XV1aS0jAjYwn98uvVCiAywQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.39.0",
-				"@typescript-eslint/type-utils": "5.39.0",
-				"@typescript-eslint/utils": "5.39.0",
+				"@typescript-eslint/scope-manager": "5.42.0",
+				"@typescript-eslint/type-utils": "5.42.0",
+				"@typescript-eslint/utils": "5.42.0",
 				"debug": "^4.3.4",
 				"ignore": "^5.2.0",
+				"natural-compare-lite": "^1.4.0",
 				"regexpp": "^3.2.0",
 				"semver": "^7.3.7",
 				"tsutils": "^3.21.0"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.39.0.tgz",
-			"integrity": "sha512-PhxLjrZnHShe431sBAGHaNe6BDdxAASDySgsBCGxcBecVCi8NQWxQZMcizNA4g0pN51bBAn/FUfkWG3SDVcGlA==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.42.0.tgz",
+			"integrity": "sha512-Ixh9qrOTDRctFg3yIwrLkgf33AHyEIn6lhyf5cCfwwiGtkWhNpVKlEZApi3inGQR/barWnY7qY8FbGKBO7p3JA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.39.0",
-				"@typescript-eslint/types": "5.39.0",
-				"@typescript-eslint/typescript-estree": "5.39.0",
+				"@typescript-eslint/scope-manager": "5.42.0",
+				"@typescript-eslint/types": "5.42.0",
+				"@typescript-eslint/typescript-estree": "5.42.0",
 				"debug": "^4.3.4"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.39.0.tgz",
-			"integrity": "sha512-/I13vAqmG3dyqMVSZPjsbuNQlYS082Y7OMkwhCfLXYsmlI0ca4nkL7wJ/4gjX70LD4P8Hnw1JywUVVAwepURBw==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.42.0.tgz",
+			"integrity": "sha512-l5/3IBHLH0Bv04y+H+zlcLiEMEMjWGaCX6WyHE5Uk2YkSGAMlgdUPsT/ywTSKgu9D1dmmKMYgYZijObfA39Wow==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.39.0",
-				"@typescript-eslint/visitor-keys": "5.39.0"
+				"@typescript-eslint/types": "5.42.0",
+				"@typescript-eslint/visitor-keys": "5.42.0"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.39.0.tgz",
-			"integrity": "sha512-KJHJkOothljQWzR3t/GunL0TPKY+fGJtnpl+pX+sJ0YiKTz3q2Zr87SGTmFqsCMFrLt5E0+o+S6eQY0FAXj9uA==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.42.0.tgz",
+			"integrity": "sha512-HW14TXC45dFVZxnVW8rnUGnvYyRC0E/vxXShFCthcC9VhVTmjqOmtqj6H5rm9Zxv+ORxKA/1aLGD7vmlLsdlOg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/typescript-estree": "5.39.0",
-				"@typescript-eslint/utils": "5.39.0",
+				"@typescript-eslint/typescript-estree": "5.42.0",
+				"@typescript-eslint/utils": "5.42.0",
 				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.39.0.tgz",
-			"integrity": "sha512-gQMZrnfEBFXK38hYqt8Lkwt8f4U6yq+2H5VDSgP/qiTzC8Nw8JO3OuSUOQ2qW37S/dlwdkHDntkZM6SQhKyPhw==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.42.0.tgz",
+			"integrity": "sha512-t4lzO9ZOAUcHY6bXQYRuu+3SSYdD9TS8ooApZft4WARt4/f2Cj/YpvbTe8A4GuhT4bNW72goDMOy7SW71mZwGw==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.39.0.tgz",
-			"integrity": "sha512-qLFQP0f398sdnogJoLtd43pUgB18Q50QSA+BTE5h3sUxySzbWDpTSdgt4UyxNSozY/oDK2ta6HVAzvGgq8JYnA==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.0.tgz",
+			"integrity": "sha512-2O3vSq794x3kZGtV7i4SCWZWCwjEtkWfVqX4m5fbUBomOsEOyd6OAD1qU2lbvV5S8tgy/luJnOYluNyYVeOTTg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.39.0",
-				"@typescript-eslint/visitor-keys": "5.39.0",
+				"@typescript-eslint/types": "5.42.0",
+				"@typescript-eslint/visitor-keys": "5.42.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -5995,43 +6008,45 @@
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.39.0.tgz",
-			"integrity": "sha512-+DnY5jkpOpgj+EBtYPyHRjXampJfC0yUZZzfzLuUWVZvCuKqSdJVC8UhdWipIw7VKNTfwfAPiOWzYkAwuIhiAg==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.42.0.tgz",
+			"integrity": "sha512-JZ++3+h1vbeG1NUECXQZE3hg0kias9kOtcQr3+JVQ3whnjvKuMyktJAAIj6743OeNPnGBmjj7KEmiDL7qsdnCQ==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.39.0",
-				"@typescript-eslint/types": "5.39.0",
-				"@typescript-eslint/typescript-estree": "5.39.0",
+				"@types/semver": "^7.3.12",
+				"@typescript-eslint/scope-manager": "5.42.0",
+				"@typescript-eslint/types": "5.42.0",
+				"@typescript-eslint/typescript-estree": "5.42.0",
 				"eslint-scope": "^5.1.1",
-				"eslint-utils": "^3.0.0"
+				"eslint-utils": "^3.0.0",
+				"semver": "^7.3.7"
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.39.0.tgz",
-			"integrity": "sha512-yyE3RPwOG+XJBLrhvsxAidUgybJVQ/hG8BhiJo0k8JSAYfk/CshVcxf0HwP4Jt7WZZ6vLmxdo1p6EyN3tzFTkg==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.0.tgz",
+			"integrity": "sha512-QHbu5Hf/2lOEOwy+IUw0GoSCuAzByTAWWrOTKzTzsotiUnWFpuKnXcAhC9YztAf2EElQ0VvIK+pHJUPkM0q7jg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.39.0",
+				"@typescript-eslint/types": "5.42.0",
 				"eslint-visitor-keys": "^3.3.0"
 			}
 		},
 		"@vitest/coverage-c8": {
-			"version": "0.23.4",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.23.4.tgz",
-			"integrity": "sha512-jmD00a5DQH9gu9K+YdvVhcMuv2CzHvU4gCnySS40Ec5hKlXtlCzRfNHl00VnhfuBeaQUmaQYe60BLT413HyDdg==",
+			"version": "0.24.5",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.24.5.tgz",
+			"integrity": "sha512-955yK/SdSBZPYrSXgXB0F+0JnOX5EY9kSL7ywJ4rNajmkFUhwLjuKm13Xb6YKSyIY/g5WvbBnyowqfNRxBJ3ww==",
 			"dev": true,
 			"requires": {
 				"c8": "^7.12.0",
-				"vitest": "0.23.4"
+				"vitest": "0.24.5"
 			}
 		},
 		"acorn": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-			"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
 			"dev": true
 		},
 		"acorn-jsx": {
@@ -6951,15 +6966,15 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "8.24.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.24.0.tgz",
-			"integrity": "sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
+			"integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
 			"dev": true,
 			"requires": {
-				"@eslint/eslintrc": "^1.3.2",
-				"@humanwhocodes/config-array": "^0.10.5",
-				"@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+				"@eslint/eslintrc": "^1.3.3",
+				"@humanwhocodes/config-array": "^0.11.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
+				"@nodelib/fs.walk": "^1.2.8",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -6975,14 +6990,14 @@
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"find-up": "^5.0.0",
-				"glob-parent": "^6.0.1",
+				"glob-parent": "^6.0.2",
 				"globals": "^13.15.0",
-				"globby": "^11.1.0",
 				"grapheme-splitter": "^1.0.4",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
+				"is-path-inside": "^3.0.3",
 				"js-sdsl": "^4.1.4",
 				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
@@ -7126,9 +7141,9 @@
 			"dev": true
 		},
 		"estree-walker": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
 		},
 		"esutils": {
 			"version": "2.0.3",
@@ -7284,6 +7299,7 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
 			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
 			"optional": true
 		},
 		"function-bind": {
@@ -7616,6 +7632,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
 			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+			"dev": true
+		},
+		"is-path-inside": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"dev": true
 		},
 		"is-plain-obj": {
@@ -8373,6 +8395,12 @@
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
 		},
+		"natural-compare-lite": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+			"dev": true
+		},
 		"neo-async": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -8516,9 +8544,9 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "8.4.16",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-			"integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+			"version": "8.4.18",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
+			"integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
 			"dev": true,
 			"requires": {
 				"nanoid": "^3.3.4",
@@ -8778,7 +8806,7 @@
 			"version": "2.79.1",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
 			"integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
-			"peer": true,
+			"devOptional": true,
 			"requires": {
 				"fsevents": "~2.3.2"
 			}
@@ -9119,9 +9147,9 @@
 			}
 		},
 		"tinybench": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.1.5.tgz",
-			"integrity": "sha512-ak+PZZEuH3mw6CCFOgf5S90YH0MARnZNhxjhjguAmoJimEMAJuNip/rJRd6/wyylHItomVpKTzZk9zrhTrQCoQ==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.3.1.tgz",
+			"integrity": "sha512-hGYWYBMPr7p4g5IarQE7XhlyWveh1EKhy4wUBS1LrHXCKYgvz+4/jCqgmJqZxxldesn05vccrtME2RLLZNW7iA==",
 			"dev": true
 		},
 		"tinypool": {
@@ -9268,33 +9296,22 @@
 			}
 		},
 		"vite": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-3.1.4.tgz",
-			"integrity": "sha512-JoQI08aBjY9lycL7jcEq4p9o1xUjq5aRvdH4KWaXtkSx7e7RpAh9D3IjzDWRD4Fg44LS3oDAIOG/Kq1L+82psA==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-3.2.2.tgz",
+			"integrity": "sha512-pLrhatFFOWO9kS19bQ658CnRYzv0WLbsPih6R+iFeEEhDOuYgYCX2rztUViMz/uy/V8cLCJvLFeiOK7RJEzHcw==",
 			"dev": true,
 			"requires": {
-				"esbuild": "^0.15.6",
+				"esbuild": "^0.15.9",
 				"fsevents": "~2.3.2",
-				"postcss": "^8.4.16",
+				"postcss": "^8.4.18",
 				"resolve": "^1.22.1",
-				"rollup": "~2.78.0"
-			},
-			"dependencies": {
-				"rollup": {
-					"version": "2.78.1",
-					"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
-					"integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
-					"dev": true,
-					"requires": {
-						"fsevents": "~2.3.2"
-					}
-				}
+				"rollup": "^2.79.1"
 			}
 		},
 		"vitest": {
-			"version": "0.23.4",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.23.4.tgz",
-			"integrity": "sha512-iukBNWqQAv8EKDBUNntspLp9SfpaVFbmzmM0sNcnTxASQZMzRw3PsM6DMlsHiI+I6GeO5/sYDg3ecpC+SNFLrQ==",
+			"version": "0.24.5",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.24.5.tgz",
+			"integrity": "sha512-zw6JhPUHtLILQDe5Q39b/SzoITkG+R7hcFjuthp4xsi6zpmfQPOZcHodZ+3bqoWl4EdGK/p1fuMiEwdxgbGLOA==",
 			"dev": true,
 			"requires": {
 				"@types/chai": "^4.3.3",
@@ -9303,11 +9320,11 @@
 				"chai": "^4.3.6",
 				"debug": "^4.3.4",
 				"local-pkg": "^0.4.2",
-				"strip-literal": "^0.4.1",
-				"tinybench": "^2.1.5",
+				"strip-literal": "^0.4.2",
+				"tinybench": "^2.3.1",
 				"tinypool": "^0.3.0",
 				"tinyspy": "^1.0.2",
-				"vite": "^2.9.12 || ^3.0.0-0"
+				"vite": "^3.0.0"
 			}
 		},
 		"which": {

--- a/package.json
+++ b/package.json
@@ -44,17 +44,17 @@
 		"size": "size-limit"
 	},
 	"dependencies": {
-		"@rollup/plugin-typescript": "^8.5.0",
+		"@rollup/plugin-typescript": "^9.0.2",
 		"defu": "^6.1.0",
 		"fs-extra": "^10.1.0"
 	},
 	"devDependencies": {
 		"@size-limit/preset-small-lib": "^8.1.0",
 		"@types/fs-extra": "^9.0.13",
-		"@typescript-eslint/eslint-plugin": "~5.39.0",
-		"@typescript-eslint/parser": "^5.39.0",
-		"@vitest/coverage-c8": "^0.23.4",
-		"eslint": "^8.24.0",
+		"@typescript-eslint/eslint-plugin": "~5.42.0",
+		"@typescript-eslint/parser": "^5.42.0",
+		"@vitest/coverage-c8": "^0.24.5",
+		"eslint": "^8.26.0",
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-prettier": "^4.2.1",
 		"eslint-plugin-tsdoc": "^0.2.17",
@@ -63,8 +63,8 @@
 		"size-limit": "^8.1.0",
 		"standard-version": "^9.5.0",
 		"typescript": "^4.8.4",
-		"vitest": "^0.23.4",
-		"vite": "^3.1.4"
+		"vitest": "^0.24.5",
+		"vite": "^3.2.2"
 	},
 	"peerDependencies": {
 		"vite": "^3.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from "vite";
 
+import { readPackageJSON } from "./lib/readPackageJSON";
+
 import { extendConfigPlugin, moveTypeDeclarationsPlugin } from "./plugins";
-import { readPackageJSON } from "./readPackageJSON";
 import type { Options } from "./types";
 
 const DEFAULT_OPTIONS = {

--- a/src/lib/readPackageJSON.ts
+++ b/src/lib/readPackageJSON.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-import { PackageJSON } from "./types";
+import { PackageJSON } from "../types";
 
 export const readPackageJSON = (rootDir = process.cwd()): PackageJSON => {
 	try {

--- a/src/plugins/extendConfig.ts
+++ b/src/plugins/extendConfig.ts
@@ -48,6 +48,14 @@ export const extendConfigPlugin = (options: Options): Plugin => {
 						declarationDir: "dist",
 						include: ["./src/**/*"],
 					}) as Plugin,
+					// Preserve dynamic imports for CommonJS
+					// TODO: Remove when Vite updates to Rollup v3. This behavior is enabled by default in v3.
+					{
+						name: "preserve-dynamic-imports",
+						renderDynamicImport() {
+							return { left: "import(", right: ")" };
+						},
+					},
 				],
 			},
 			minify: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR preserves `import()` calls in CommonJS outputs. Without this PR, `import()` is converted to `require()` automatically due to Rollup's default behavior.

Once Vite upgrades Rollup from v2 to v3, the inlined `preserve-dynamic-imports` plugin can be removed; Rollup 3 [preserves dynamic imports by default](https://rollupjs.org/guide/en/#outputdynamicimportincjs).

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
