### PR TITLE
feat: add `internalDependencies` option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import type { Options } from "./types";
 
 const DEFAULT_OPTIONS = {
 	dts: true,
+	internalDependencies: [],
 };
 
 const sdkPlugin = (rawOptions?: Partial<Options>): (Plugin | null)[] => {

--- a/src/plugins/extendConfig.ts
+++ b/src/plugins/extendConfig.ts
@@ -35,7 +35,12 @@ export const extendConfigPlugin = (options: Options): Plugin => {
 						...Object.keys(options.packageJSON.optionalDependencies ?? {}),
 						...Object.keys(options.packageJSON.peerDependencies ?? {}),
 					].map((name) => new RegExp(`^${name}(?:\/.*)?$`)),
-				],
+				].filter(
+					(regexp) =>
+						!options.internalDependencies.some((internalDependency) =>
+							regexp.test(internalDependency),
+						),
+				),
 				output: {
 					preserveModules: true,
 					preserveModulesRoot: "src",

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,11 @@ export interface Options {
 	 * @defaultValue `true`
 	 */
 	dts: boolean;
+
+	/**
+	 * A list of dependencies to ignore from Rollup's `external` option.
+	 */
+	internalDependencies: string[];
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds an `internalDependencies` option that lets one define a list of dependencies to transpile. This option lets someone exclude a dependency from the automatically populated `rollupOptions.externals` option.

```ts
// vite.config.ts
import { defineConfig } from "vite";
import sdk from "vite-plugin-sdk";

export default defineConfig({
	plugins: [
		sdk({
			// Ensure `fp-ts` and `devalue` are not treated as external.
			internalDependencies: ["fp-ts", "devalue"],
		}),
	],
});

```

**Note**: `defun()` from `defu` is used internally to allow overriding `vue-plugin-sdk`'s config. Arrays are always merged by default, which makes omiting a result difficult. A function value can be provided that lets someone modify the default array (including adding or removing elements), but it is not properly typed. Adding a new `internalDependencies` option is just one way to overcome this limitation.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
