### PR TITLE
fix: move type declaration only if declarations exist

### DIFF
--- a/src/plugins/moveTypeDeclarations.ts
+++ b/src/plugins/moveTypeDeclarations.ts
@@ -14,9 +14,11 @@ export const moveTypeDeclarationsPlugin = (options: Options): Plugin | null => {
 		name: "sdk:move-type-declarations",
 		apply: "build",
 		closeBundle: () => {
-			// TODO: Replace with native Node 16 compatible version when 14 is EOL
-			fse.copySync("./dist/src", "./dist", { recursive: true });
-			fs.rmSync("./dist/src", { recursive: true });
+			if (fs.existsSync("./dist/src")) {
+				// TODO: Replace with native Node 16 compatible version when 14 is EOL
+				fse.copySync("./dist/src", "./dist", { recursive: true });
+				fs.rmSync("./dist/src", { recursive: true });
+			}
 		},
 	};
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR ensures type declaration files are only moved if they have been emitted.

Without this PR, the `move-types-declarations` internal plugin would throw when trying to copy `./dist/src`.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
