### PR TITLE
refactor: `srcDir` to `entryDir`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import type { Options } from "./types";
 const DEFAULT_OPTIONS = {
 	dts: true,
 	internalDependencies: [],
-	srcDir: "src",
+	entryDir: "src",
 };
 
 const sdkPlugin = (rawOptions?: Partial<Options>): (Plugin | null)[] => {

--- a/src/lib/castArray.ts
+++ b/src/lib/castArray.ts
@@ -1,0 +1,12 @@
+/**
+ * Ensures that a value is an array. If it is already an array, it is returned
+ * as is. If it is not an array, it is converted to an array with itself as its
+ * only element.
+ *
+ * @typeParam A - Element of the array.
+ *
+ * @param a - Value to ensure is an array.
+ *
+ * @returns `a` as an array.
+ */
+export const castArray = <A>(a: A | A[]): A[] => (Array.isArray(a) ? a : [a]);

--- a/src/plugins/extendConfig.ts
+++ b/src/plugins/extendConfig.ts
@@ -5,6 +5,7 @@ import { defineConfig, Plugin, UserConfig } from "vite";
 import { defuFn } from "defu";
 
 import { builtins } from "../lib/builtins";
+import { castArray } from "../lib/castArray";
 import type { Options } from "../types";
 
 export const extendConfigPlugin = (options: Options): Plugin => {
@@ -12,7 +13,7 @@ export const extendConfigPlugin = (options: Options): Plugin => {
 		defineConfig({
 			build: {
 				lib: {
-					entry: path.posix.join(options.srcDir, "index.ts"),
+					entry: "./src/index.ts",
 					formats: ["es", "cjs"],
 					fileName: (format) => {
 						switch (format) {
@@ -48,7 +49,7 @@ export const extendConfigPlugin = (options: Options): Plugin => {
 					),
 					output: {
 						preserveModules: true,
-						preserveModulesRoot: options.srcDir,
+						preserveModulesRoot: castArray(options.entryDir).shift(),
 						inlineDynamicImports: false,
 					},
 					plugins: [
@@ -56,7 +57,9 @@ export const extendConfigPlugin = (options: Options): Plugin => {
 							rootDir: ".",
 							declaration: options.dts,
 							declarationDir: userConfig.build?.outDir || "dist",
-							include: [path.posix.join(options.srcDir, "**/*")],
+							include: castArray(options.entryDir).map((dir) =>
+								path.posix.join(dir, "**/*"),
+							),
 						}) as Plugin,
 						// Preserve dynamic imports for CommonJS
 						// TODO: Remove when Vite updates to Rollup v3. This behavior is enabled by default in v3.

--- a/src/plugins/moveTypeDeclarations.ts
+++ b/src/plugins/moveTypeDeclarations.ts
@@ -5,6 +5,7 @@ import fse from "fs-extra";
 import type { Plugin, UserConfig } from "vite";
 
 import { Options } from "../types";
+import { castArray } from "../lib/castArray";
 
 export const moveTypeDeclarationsPlugin = (options: Options): Plugin | null => {
 	if (!options.dts) {
@@ -21,12 +22,15 @@ export const moveTypeDeclarationsPlugin = (options: Options): Plugin | null => {
 		},
 		closeBundle: () => {
 			const outDir = savedUserConfig.build?.outDir || "dist";
-			const srcOutDir = path.posix.join(outDir, options.srcDir);
 
-			if (fs.existsSync(srcOutDir)) {
-				// TODO: Replace with native Node 16 compatible version when 14 is EOL
-				fse.copySync(srcOutDir, outDir, { recursive: true });
-				fs.rmSync(srcOutDir, { recursive: true });
+			for (const entryDir of castArray(options.entryDir)) {
+				const entryOutDir = path.posix.join(outDir, entryDir);
+
+				if (fs.existsSync(entryOutDir)) {
+					// TODO: Replace with native Node 16 compatible version when 14 is EOL
+					fse.copySync(entryOutDir, outDir, { recursive: true });
+					fs.rmSync(entryOutDir, { recursive: true });
+				}
 			}
 		},
 	};

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,11 +22,11 @@ export interface Options {
 	internalDependencies: string[];
 
 	/**
-	 * Directory to consider as the root `src` directory
+	 * Directories to consider as entry directory for type generation.
 	 *
 	 * @defaultValue `src`
 	 */
-	srcDir: string;
+	entryDir: string | string[];
 }
 
 /**


### PR DESCRIPTION
Took a stab at that:

> ### `srcDir`
> What happens when someone has multiple entries in different directories? For example:
> 
> * `/cli/index.ts`
> * `/components/index.ts`
> * `/utils/index.ts`
> 
> Note that none of them are in a `src` directory
> `srcDir` would be irrelevant in this case since you can only define one root directory.
> 
> Would it make sense to have an `entryDir` option instead and supports a string or array of strings, like `build.lib.entry`? From that, we can more accurately generate TypeScript types and move them correctly in `sdk:move-type-declarations` by only touching those directories.
> 
> (Alternatively, `srcDir` could accept an array and be used in the same way I described `entryDir`.)

But I'm not sure on the `preserveModulesRoot` implementation 🤔 Should we disable it in the above case?