### PR TITLE
fix: publish internal dependencies to npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
 				"eslint-plugin-tsdoc": "^0.2.17",
 				"prettier": "^2.8.1",
 				"prettier-plugin-jsdoc": "^0.4.2",
+				"rollup-plugin-rename-node-modules": "^1.3.1",
 				"size-limit": "^8.1.0",
 				"standard-version": "^9.5.0",
 				"typescript": "^4.9.4",
@@ -3588,6 +3589,15 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/magic-string": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+			"dev": true,
+			"dependencies": {
+				"sourcemap-codec": "^1.4.8"
+			}
+		},
 		"node_modules/make-dir": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -5000,19 +5010,32 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "3.7.4",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.7.4.tgz",
-			"integrity": "sha512-jN9rx3k5pfg9H9al0r0y1EYKSeiRANZRYX32SuNXAnKzh6cVyf4LZVto1KAuDnbHT03E1CpsgqDKaqQ8FZtgxw==",
+			"version": "2.79.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+			"integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
 			"devOptional": true,
+			"peer": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
 			},
 			"engines": {
-				"node": ">=14.18.0",
-				"npm": ">=8.0.0"
+				"node": ">=10.0.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/rollup-plugin-rename-node-modules": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-rename-node-modules/-/rollup-plugin-rename-node-modules-1.3.1.tgz",
+			"integrity": "sha512-46TUPqO94GXuACYqVZjdbzNXTQAp+wTdZg/vUx2gaINb0da/ZPdaOtno2RGUOKBF4sbVM9v2ZqV98r4TQbp1UA==",
+			"dev": true,
+			"dependencies": {
+				"estree-walker": "^2.0.1",
+				"magic-string": "^0.25.7"
+			},
+			"peerDependencies": {
+				"rollup": "^2.28.2"
 			}
 		},
 		"node_modules/run-parallel": {
@@ -5160,6 +5183,13 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/sourcemap-codec": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+			"deprecated": "Please use @jridgewell/sourcemap-codec instead",
+			"dev": true
 		},
 		"node_modules/spdx-correct": {
 			"version": "3.1.1",
@@ -5791,6 +5821,22 @@
 				"@esbuild/win32-arm64": "0.16.7",
 				"@esbuild/win32-ia32": "0.16.7",
 				"@esbuild/win32-x64": "0.16.7"
+			}
+		},
+		"node_modules/vite/node_modules/rollup": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.9.1.tgz",
+			"integrity": "sha512-GswCYHXftN8ZKGVgQhTFUJB/NBXxrRGgO2NCy6E8s1rwEJ4Q9/VttNqcYfEvx4dTo4j58YqdC3OVztPzlKSX8w==",
+			"dev": true,
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=14.18.0",
+				"npm": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
 			}
 		},
 		"node_modules/vitest": {
@@ -8424,6 +8470,15 @@
 				"yallist": "^4.0.0"
 			}
 		},
+		"magic-string": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+			"dev": true,
+			"requires": {
+				"sourcemap-codec": "^1.4.8"
+			}
+		},
 		"make-dir": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -9346,12 +9401,23 @@
 			}
 		},
 		"rollup": {
-			"version": "3.7.4",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.7.4.tgz",
-			"integrity": "sha512-jN9rx3k5pfg9H9al0r0y1EYKSeiRANZRYX32SuNXAnKzh6cVyf4LZVto1KAuDnbHT03E1CpsgqDKaqQ8FZtgxw==",
+			"version": "2.79.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+			"integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
 			"devOptional": true,
+			"peer": true,
 			"requires": {
 				"fsevents": "~2.3.2"
+			}
+		},
+		"rollup-plugin-rename-node-modules": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-rename-node-modules/-/rollup-plugin-rename-node-modules-1.3.1.tgz",
+			"integrity": "sha512-46TUPqO94GXuACYqVZjdbzNXTQAp+wTdZg/vUx2gaINb0da/ZPdaOtno2RGUOKBF4sbVM9v2ZqV98r4TQbp1UA==",
+			"dev": true,
+			"requires": {
+				"estree-walker": "^2.0.1",
+				"magic-string": "^0.25.7"
 			}
 		},
 		"run-parallel": {
@@ -9440,6 +9506,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
 			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+			"dev": true
+		},
+		"sourcemap-codec": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
 			"dev": true
 		},
 		"spdx-correct": {
@@ -9893,6 +9965,15 @@
 						"@esbuild/win32-arm64": "0.16.7",
 						"@esbuild/win32-ia32": "0.16.7",
 						"@esbuild/win32-x64": "0.16.7"
+					}
+				},
+				"rollup": {
+					"version": "3.9.1",
+					"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.9.1.tgz",
+					"integrity": "sha512-GswCYHXftN8ZKGVgQhTFUJB/NBXxrRGgO2NCy6E8s1rwEJ4Q9/VttNqcYfEvx4dTo4j58YqdC3OVztPzlKSX8w==",
+					"dev": true,
+					"requires": {
+						"fsevents": "~2.3.2"
 					}
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -60,11 +60,12 @@
 		"eslint-plugin-tsdoc": "^0.2.17",
 		"prettier": "^2.8.1",
 		"prettier-plugin-jsdoc": "^0.4.2",
+		"rollup-plugin-rename-node-modules": "^1.3.1",
 		"size-limit": "^8.1.0",
 		"standard-version": "^9.5.0",
 		"typescript": "^4.9.4",
-		"vitest": "^0.25.8",
-		"vite": "^4.0.1"
+		"vite": "^4.0.1",
+		"vitest": "^0.25.8"
 	},
 	"peerDependencies": {
 		"vite": "^4.0.0"

--- a/src/plugins/extendConfig.ts
+++ b/src/plugins/extendConfig.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 
 import typescript from "@rollup/plugin-typescript";
+import renameNodeModules from "rollup-plugin-rename-node-modules";
 import { defineConfig, Plugin, UserConfig } from "vite";
 import { defuFn } from "defu";
 
@@ -58,6 +59,9 @@ export const extendConfigPlugin = (options: Options): Plugin => {
 							outDir: userConfig.build?.outDir || "dist",
 							include: [path.posix.join(options.srcDir, "**/*")],
 						}) as Plugin,
+						// Ensure bundled dependencies are published to npm.
+						// `npm pack` ignores directories named `node_modules`.
+						renameNodeModules("_node_modules") as Plugin,
 					],
 				},
 				minify: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds `rollup-plugin-rename-node-modules` to the default Vite config.

The plugin is necessary to include `node_modules` in the packaged code, which is needed when `vite-plugin-sdk`'s `internalDependencies` option is used.

For more details on the purpose of the plugin, [see its README](https://github.com/Lazyuki/rollup-plugin-rename-node-modules#why).

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐈
