### PR TITLE
feat: add `.js` extension to imports and exports in `.d.ts` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.5-alpha.1](https://github.com/prismicio-community/vite-plugin-sdk/compare/v0.1.5-alpha.0...v0.1.5-alpha.1) (2025-10-15)
+
+
+### Bug Fixes
+
+* support `export` declarations ([cd292bd](https://github.com/prismicio-community/vite-plugin-sdk/commit/cd292bd75a6342d4e43c254b3d129c8c1d3aa5a8))
+
 ### [0.1.5-alpha.0](https://github.com/prismicio-community/vite-plugin-sdk/compare/v0.1.4...v0.1.5-alpha.0) (2025-10-15)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.5-alpha.0](https://github.com/prismicio-community/vite-plugin-sdk/compare/v0.1.4...v0.1.5-alpha.0) (2025-10-15)
+
+
+### Features
+
+* add `.js` import extensions in `.d.ts` files ([1a7d5b0](https://github.com/prismicio-community/vite-plugin-sdk/commit/1a7d5b009a1e725d78f5f681e12a55afed6144b1))
+
 ### [0.1.4](https://github.com/prismicio-community/vite-plugin-sdk/compare/v0.1.3...v0.1.4) (2025-07-29)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vite-plugin-sdk",
-	"version": "0.1.4",
+	"version": "0.1.5-alpha.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vite-plugin-sdk",
-			"version": "0.1.4",
+			"version": "0.1.5-alpha.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@rollup/plugin-typescript": "^12.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vite-plugin-sdk",
-	"version": "0.1.5-alpha.0",
+	"version": "0.1.5-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vite-plugin-sdk",
-			"version": "0.1.5-alpha.0",
+			"version": "0.1.5-alpha.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@rollup/plugin-typescript": "^12.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
 				"prettier-plugin-jsdoc": "^1.3.3",
 				"size-limit": "^11.2.0",
 				"standard-version": "^9.5.0",
-				"typescript": "^5.8.3",
 				"typescript-eslint": "^8.38.0",
 				"vite": "^6.0.2",
 				"vitest": "^3.2.4"
@@ -37,6 +36,8 @@
 				"node": ">=14.15.0"
 			},
 			"peerDependencies": {
+				"tslib": "^2",
+				"typescript": "^5",
 				"vite": "^4 || ^5 || ^6 || ^7"
 			}
 		},
@@ -7075,7 +7076,6 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"license": "0BSD",
-			"optional": true,
 			"peer": true
 		},
 		"node_modules/type-check": {
@@ -7116,6 +7116,7 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
 			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vite-plugin-sdk",
-	"version": "0.1.5-alpha.0",
+	"version": "0.1.5-alpha.1",
 	"description": "Vite plugin to bundle SDKs",
 	"keywords": [
 		"typescript",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vite-plugin-sdk",
-	"version": "0.1.4",
+	"version": "0.1.5-alpha.0",
 	"description": "Vite plugin to bundle SDKs",
 	"keywords": [
 		"typescript",

--- a/package.json
+++ b/package.json
@@ -63,12 +63,13 @@
 		"prettier-plugin-jsdoc": "^1.3.3",
 		"size-limit": "^11.2.0",
 		"standard-version": "^9.5.0",
-		"typescript": "^5.8.3",
 		"typescript-eslint": "^8.38.0",
 		"vite": "^6.0.2",
 		"vitest": "^3.2.4"
 	},
 	"peerDependencies": {
+		"tslib": "^2",
+		"typescript": "^5",
 		"vite": "^4 || ^5 || ^6 || ^7"
 	},
 	"engines": {

--- a/src/plugins/extendConfig.ts
+++ b/src/plugins/extendConfig.ts
@@ -62,7 +62,7 @@ export const extendConfigPlugin = (options: Options): Plugin => {
 							outDir: userConfig.build?.outDir || "dist",
 							include: [path.posix.join(options.srcDir, "**/*")],
 							transformers: {
-								afterDeclarations: [addImportExtensionsTransformer],
+								afterDeclarations: [addImportExportExtensionsTransformer],
 							},
 						}) as Plugin,
 						// Ensure bundled dependencies are published to npm.
@@ -93,7 +93,9 @@ export const extendConfigPlugin = (options: Options): Plugin => {
  * Adds a `.js` extension to all import and export declarations that do not
  * contain an extension.
  */
-function addImportExtensionsTransformer(context: ts.TransformationContext) {
+function addImportExportExtensionsTransformer(
+	context: ts.TransformationContext,
+) {
 	return (source: ts.Bundle | ts.SourceFile) => {
 		function visitor(node: ts.Node) {
 			function shouldAddExtension(moduleSpecifier: ts.StringLiteral) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

This PR automatically adds a `.js` extension to imports and exports in generated `.d.ts` files. Imports and exports that already contain an extension are ignored.

**Before**:

```ts
// index.d.ts
import { Ref } from '../types'
import { Client } from '../client.js'
export { BooleanField } from './fields'
```

**After**:

```ts
// index.d.ts
import { Ref } from '../types.js'
import { Client } from '../client.js' // untouched
export { BooleanField } from './fields.js'
```

See: https://github.com/prismicio/prismic-client/issues/399

> [!NOTE]
> `typescript` and `tslib` were moved to peer dependencies, as is required by `@rollup/plugin-typescript`. Building this package locally threw an error for not having `tslib` explicitly installed.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
